### PR TITLE
GitKraken Fix to ignore template

### DIFF
--- a/Topics/GitHub/gitignore_template_general.txt
+++ b/Topics/GitHub/gitignore_template_general.txt
@@ -65,3 +65,11 @@
 !/**/Output/**/*.xml
 !/**/Output/**/*.eps
 !/**/Output/**/*.svg
+
+#######################
+## Include all the password/token files here.
+## This makes sure that they are not committed or pushed.
+password.r
+password.py
+API.py 
+password.do

--- a/Topics/GitHub/gitignore_template_general.txt
+++ b/Topics/GitHub/gitignore_template_general.txt
@@ -12,6 +12,9 @@
 # we recommend that you generate an ignore file using GitHub and simply replace
 # the content of that file.
 #
+# Note that if you are using GitKraken you need to use version 5.x or more
+# recent for this template to work properly
+#
 ########################################################################
 
 #######################

--- a/Topics/GitHub/gitignore_template_general.txt
+++ b/Topics/GitHub/gitignore_template_general.txt
@@ -75,9 +75,12 @@
 !/**/Output/**/*.svg
 
 #######################
-## Include all the password/token files here.
-## This makes sure that they are not committed or pushed.
-password.r
-password.py
-API.py 
-password.do
+# Include all the files with passwords or tokens here. All files named
+# password or passwords are with this template ignored no matter which
+# format you are using. Additionally, all content in any folder called
+password or passwords are also ignored. NOTE that your project might be
+using different names and then you must edit the lines below accordingly.
+password.*
+passwords.*
+password/
+passwords/

--- a/Topics/GitHub/gitignore_template_general.txt
+++ b/Topics/GitHub/gitignore_template_general.txt
@@ -17,7 +17,7 @@
 #######################
 # Start by ignoring everything, and below we are explicitly saying
 # what to not ignore
-**
+*
 
 #######################
 # List of files with GitHub functionality anywhere in the repo
@@ -30,6 +30,14 @@
 # Keep markdown files used for documentation on GitHub
 !README.md
 !CONTRIBUTING.md
+
+#######################
+# For performance reasons, if a folder is already ignored, then
+# GitHub does not check the content for that folder for matches
+# with additional rules. The line below includes folder in the
+# top folder (but not their content), so that anything matching
+# the rules below will still not be ignored.
+!*/
 
 #######################
 # The following file types are code that should always be

--- a/Topics/GitHub/gitignore_template_general.txt
+++ b/Topics/GitHub/gitignore_template_general.txt
@@ -17,7 +17,7 @@
 #######################
 # Start by ignoring everything, and below we are explicitly saying
 # what to not ignore
-*
+**
 
 #######################
 # List of files with GitHub functionality anywhere in the repo
@@ -30,14 +30,6 @@
 # Keep markdown files used for documentation on GitHub
 !README.md
 !CONTRIBUTING.md
-
-#######################
-# For performance reasons, if a folder is already ignored, then
-# GitHub does not check the content for that folder for matches
-# with additional rules. The line below includes folder in the
-# top folder (but not their content), so that anything matching
-# the rules below will still not be ignored.
-!*/
 
 #######################
 # The following file types are code that should always be

--- a/Topics/GitHub/gitignore_template_iefolder.txt
+++ b/Topics/GitHub/gitignore_template_iefolder.txt
@@ -19,7 +19,7 @@
 #######################
 # Start by ignoring everything, and below we are explicitly saying
 # what to not ignore
-*
+**
 
 #######################
 # List of files with GitHub functionality anywhere in the repo
@@ -32,14 +32,6 @@
 # Keep markdown files used for documentation on GitHub
 !README.md
 !CONTRIBUTING.md
-
-#######################
-# For performance reasons, if a folder is already ignored, then
-# GitHub does not check the content for that folder for matches
-# with additional rules. The line below includes folder in the
-# top folder (but not their content), so that anything matching
-# the rules below will still not be ignored.
-!*/
 
 #######################
 # The following file types are code that should always be

--- a/Topics/GitHub/gitignore_template_iefolder.txt
+++ b/Topics/GitHub/gitignore_template_iefolder.txt
@@ -19,7 +19,7 @@
 #######################
 # Start by ignoring everything, and below we are explicitly saying
 # what to not ignore
-**
+*
 
 #######################
 # List of files with GitHub functionality anywhere in the repo
@@ -32,6 +32,14 @@
 # Keep markdown files used for documentation on GitHub
 !README.md
 !CONTRIBUTING.md
+
+#######################
+# For performance reasons, if a folder is already ignored, then
+# GitHub does not check the content for that folder for matches
+# with additional rules. The line below includes folder in the
+# top folder (but not their content), so that anything matching
+# the rules below will still not be ignored.
+!*/
 
 #######################
 # The following file types are code that should always be

--- a/Topics/GitHub/gitignore_template_iefolder.txt
+++ b/Topics/GitHub/gitignore_template_iefolder.txt
@@ -14,6 +14,9 @@
 # we recommend that you generate an ignore file using GitHub and simply replace
 # the content of that file.
 #
+# Note that if you are using GitKraken you need to use version 5.x or more
+# recent for this template to work properly
+#
 ########################################################################
 
 #######################

--- a/Topics/GitHub/gitignore_template_iefolder.txt
+++ b/Topics/GitHub/gitignore_template_iefolder.txt
@@ -77,3 +77,14 @@
 #######################
 # Explicitly exclude the encrypted folder branch
 **/EncryptedData/
+
+#######################
+# Include all the files with passwords or tokens here. All files named
+# password or passwords are with this template ignored no matter which
+# format you are using. Additionally, all content in any folder called
+password or passwords are also ignored. NOTE that your project might be
+using different names and then you must edit the lines below accordingly.
+password.*
+passwords.*
+password/
+passwords/


### PR DESCRIPTION
Updating the _.gitignore_ template so that it works with GitKraken. We had a discussion today on Slack that lead up to this solution: https://stackoverflow.com/questions/51089705/gitkraken-is-not-ignoring-cache-files-in-gitignore

In short, when we set up a more advanced .gitignore file, like when we ignore eveything but .do, .md, .R, .py etc. files, then GitKraken works differently than everywhere else. The StackOverflow link above provides a solution to this. I have implemented that in our template. I have tested this in two repositories where I encountered this issue. Can at least a few of you also test this _.gitignore_?

Let me know if you have time to do so. If you already are using our template then the modification needed to test this solution is very minor.

Thanks!